### PR TITLE
install python module to custom prefix

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -2,7 +2,7 @@ all:
 	python2 ./setup.py build
 
 install:
-	python2 ./setup.py install
+	python2 ./setup.py install --prefix=$(PREFIX) --root=$(DESTDIR)
 
 doc:
 	make -C doc generate


### PR DESCRIPTION
Hi, when trying to create a package for my distro, I found that there was no way to indicate a custom prefix for python modules. The default location is inaccessible to the build process in my case. I'm supposed to install python modules in a separate directory.

This change allows one to install the python module in a custom directory. This changes the default behaviour where the python module would be installed in /usr/lib. By default it would now install in /usr/local/lib. I don't know python enough to know whether that's a problem.