### PR TITLE
fix: Fix out.ini empty lines

### DIFF
--- a/ocaml/src/domains/unrels.ml
+++ b/ocaml/src/domains/unrels.ml
@@ -94,7 +94,7 @@ module Make(D: Unrel.T) =
       | Val m' ->
          List.fold_left (fun acc (u, id') ->
                               let msg = Log.History.get_msg id' in
-                              (Printf.sprintf "\n[node %d - unrel %d]\ndescription =  %s" id id' msg)::((U.to_string u)@acc)
+                              (Printf.sprintf "\n[node %d - unrel %d]\ndescription =  %s" id id' (String.trim msg))::((U.to_string u)@acc)
                              ) [] m'
 
     let imprecise_value_of_exp e =

--- a/ocaml/src/utils/log.ml
+++ b/ocaml/src/utils/log.ml
@@ -261,9 +261,8 @@ module History =
       if preds = [] then
         ""
       else
-        List.fold_left (fun acc pred ->
-            msg ^ " " ^ (get_msg pred) ^ " " ^ acc
-          ) "" preds
-                           
+        String.trim(List.fold_left (fun acc pred ->
+          String.trim(msg ^ " " ^ (get_msg pred) ^ " " ^ acc)
+          ) "" preds)
 
   end


### PR DESCRIPTION
Hello,

I'm unsure of the pertinence of the change, but I did the job for me to fix #115 .

This prevents the `out.ini` file to accumulate empty lines.