### PR TITLE
Fix TOP taint represention in IDA plugin

### DIFF
--- a/python/idabincat/bcplugin.py
+++ b/python/idabincat/bcplugin.py
@@ -686,7 +686,10 @@ class State(object):
                     tainted = True
                     if node.taintsrc:
                         # Take the first one
-                        taint_id = int(node.taintsrc[0].split("-")[1])
+                        try:
+                            taint_id = int(node.taintsrc[0].split("-")[1])
+                        except IndexError: # Taint is TOP
+                            taint_id = 0
                     break
 
             if tainted:


### PR DESCRIPTION
Fix a bug when the taint of a node is set to TOP and still apply a color.

```
[node 0]
address = 0x18c020
bytes = 55
final =false
tainted=?
```
